### PR TITLE
trim decimal bug when precision is 0

### DIFF
--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -660,15 +660,14 @@ class XBRLParser(object):
         encoded = s.encode('ascii', 'ignore')
         str_val = ""
         if six.PY3:
-            str_val = str(encoded, encoding='ascii',
-                          errors='ignore')[:precision]
+            str_val = str(encoded, encoding='ascii', errors='ignore')[:precision]
         else:
-			#If precision is 0, this must be handled seperately
-        	if precision > 0:
-            	str_val = str(encoded)[:precision]
+            #If precision is 0, this must be handled seperately
+            if precision > 0:
+                str_val = str(encoded)[:precision]
             #No trimming required
-			else:
-            	str_val = str(encoded)
+            else:
+                str_val = str(encoded)
         if len(str_val) > 0:
             return float(str_val)
         else:

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -663,9 +663,11 @@ class XBRLParser(object):
             str_val = str(encoded, encoding='ascii',
                           errors='ignore')[:precision]
         else:
+			#If precision is 0, this must be handled seperately
         	if precision > 0:
             	str_val = str(encoded)[:precision]
-            else:
+            #No trimming required
+			else:
             	str_val = str(encoded)
         if len(str_val) > 0:
             return float(str_val)

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -662,10 +662,10 @@ class XBRLParser(object):
         if six.PY3:
             str_val = str(encoded, encoding='ascii', errors='ignore')[:precision]
         else:
-            #If precision is 0, this must be handled seperately
+            # If precision is 0, this must be handled seperately
             if precision > 0:
                 str_val = str(encoded)[:precision]
-            #No trimming required
+            # No trimming required
             else:
                 str_val = str(encoded)
         if len(str_val) > 0:

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -663,11 +663,10 @@ class XBRLParser(object):
             str_val = str(encoded, encoding='ascii', errors='ignore')[:precision]
         else:
             # If precision is 0, this must be handled seperately
-            if precision > 0:
-                str_val = str(encoded)[:precision]
-            # No trimming required
-            else:
+            if precision == 0:
                 str_val = str(encoded)
+            else:
+                str_val = str(encoded)[:precision]
         if len(str_val) > 0:
             return float(str_val)
         else:

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -663,7 +663,10 @@ class XBRLParser(object):
             str_val = str(encoded, encoding='ascii',
                           errors='ignore')[:precision]
         else:
-            str_val = str(encoded)[:precision]
+        	if precision > 0:
+            	str_val = str(encoded)[:precision]
+            else:
+            	str_val = str(encoded)
         if len(str_val) > 0:
             return float(str_val)
         else:


### PR DESCRIPTION
Fixing a bug in `trim_decimals`: when the precision is 0, `str_val = str(encoded)[:precision]` will set `str_val` to be the empty string. This will return 0 as per the final branch of the conditional statement, even if `encoded` was a string representing a non-zero number.
