### PR TITLE
guard against list index out of range exception

### DIFF
--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -696,7 +696,8 @@ class XBRLParser(object):
                                          'no_context': False})
 
         if options['type'] == 'String':
-            return elements[0].text
+            if len(elements) > 0:
+                    return elements[0].text
 
         if options['no_context'] == True:
             if len(elements) > 0 and XBRLParser().is_number(elements[0].text):


### PR DESCRIPTION
This patch fixes an issue where the elements list could be empty, and referencing the first element would result in an "index out of range" exception.
