### PR TITLE
The example in the README has been updated to reflect the fact that

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ First parse the incoming XRBL file into a new ``XBRL`` basic object
 ::
 
     xbrl_parser = XBRLParser()
-    xbrl = xbrl_parser.parse(file("sam-20131228.xml"))
+    xbrl = xbrl_parser.parse(open("sam-20131228.xml"))
 
 Then you can parse the document using different parsers
 


### PR DESCRIPTION
file() is not supported in python 3 and it's recomended to use open()
instead.

https://docs.python.org/2/library/functions.html#file