### PR TITLE
- Fixes issues described in Issue #39

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,1 +1,2 @@
 Joe Cabrera
+Robert Rennison

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -161,7 +161,7 @@ def test_parse_GAAP10K_RRDonnelley():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 444075.0 
+    assert result.data['assets'] == 444075.0
     assert result.data['gross_profit'] == 104628.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
     assert result.data['current_assets'] == 164278.0
@@ -432,7 +432,7 @@ def test_parse_GAAP10K_Rivet():
     assert result.data['assets'] == 15912.0
     assert result.data['gross_profit'] == 2784.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] ==13330.0
+    assert result.data['current_assets'] == 13330.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -496,7 +496,7 @@ def test_parse_GAAP10Q_QXInteractive():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 153524.0  
+    assert result.data['assets'] == 153524.0
     assert result.data['gross_profit'] == 11188.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
     assert result.data['current_assets'] == 106114.0
@@ -602,7 +602,7 @@ def test_parse_GAAP10Q_Fujitsu():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 414512.0
-    assert result.data['non_current_assets'] == 3568474.0  
+    assert result.data['non_current_assets'] == 3568474.0
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == 26657.0
     assert result.data['liabilities_and_equity'] == 4100064.0
@@ -633,7 +633,7 @@ def test_parse_GAAP10Q_Fujitsu():
     assert result.data['assets'] == 4100064.0
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 531590.0 
+    assert result.data['current_assets'] == 531590.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -669,7 +669,7 @@ def test_parse_GAAP10K_Fujitsu():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 0.0
-    assert result.data['non_current_assets'] == 3124306.0 
+    assert result.data['non_current_assets'] == 3124306.0
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == 0.0
     assert result.data['liabilities_and_equity'] == 3718259.0
@@ -697,7 +697,7 @@ def test_parse_GAAP10K_Fujitsu():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 3718259.0 
+    assert result.data['assets'] == 3718259.0
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
     assert result.data['current_assets'] == 593953.0
@@ -736,7 +736,7 @@ def test_parse_GAAP10Q_Ez_XBRL():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 0.0
-    assert result.data['non_current_assets'] == 58615.0 
+    assert result.data['non_current_assets'] == 58615.0
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == -7593.0
     assert result.data['liabilities_and_equity'] == 79451.0
@@ -764,7 +764,7 @@ def test_parse_GAAP10Q_Ez_XBRL():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 79451.0 
+    assert result.data['assets'] == 79451.0
     assert result.data['gross_profit'] == 5433.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
     assert result.data['current_assets'] == 20836.0

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -95,10 +95,10 @@ def test_parse_GAAP10Q_RRDonnelley():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 5417.0
+    assert result.data['assets'] == 376766.0
     assert result.data['gross_profit'] == 97132.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 138996.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -161,10 +161,10 @@ def test_parse_GAAP10K_RRDonnelley():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 1050.0
+    assert result.data['assets'] == 444075.0 
     assert result.data['gross_profit'] == 104628.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 164278.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -231,7 +231,7 @@ def test_parse_GAAP10K_Webfilings():
     assert result.data['assets'] == 110920.0
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 72886.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -298,7 +298,7 @@ def test_parse_GAAP10Q_Webfilings():
     assert result.data['assets'] == 121608.0
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 77905.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -365,7 +365,7 @@ def test_parse_GAAP10Q_Rivet():
     assert result.data['assets'] == 13261.0
     assert result.data['gross_profit'] == 2687.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 10747.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -432,7 +432,7 @@ def test_parse_GAAP10K_Rivet():
     assert result.data['assets'] == 15912.0
     assert result.data['gross_profit'] == 2784.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] ==13330.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -496,10 +496,10 @@ def test_parse_GAAP10Q_QXInteractive():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 106114.0
+    assert result.data['assets'] == 153524.0  
     assert result.data['gross_profit'] == 11188.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 46431.0
+    assert result.data['current_assets'] == 106114.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -563,10 +563,10 @@ def test_parse_GAAP10K_ThomsonReuters():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 77936.0
+    assert result.data['assets'] == 111057.0
     assert result.data['gross_profit'] == 6676.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 32944.0
+    assert result.data['current_assets'] == 77936.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -602,7 +602,7 @@ def test_parse_GAAP10Q_Fujitsu():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 414512.0
-    assert result.data['non_current_assets'] == -28977.0
+    assert result.data['non_current_assets'] == 3568474.0  
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == 26657.0
     assert result.data['liabilities_and_equity'] == 4100064.0
@@ -630,10 +630,10 @@ def test_parse_GAAP10Q_Fujitsu():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 28977.0
+    assert result.data['assets'] == 4100064.0
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 531590.0 
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -669,7 +669,7 @@ def test_parse_GAAP10K_Fujitsu():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 0.0
-    assert result.data['non_current_assets'] == -1859.0
+    assert result.data['non_current_assets'] == 3124306.0 
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == 0.0
     assert result.data['liabilities_and_equity'] == 3718259.0
@@ -697,10 +697,10 @@ def test_parse_GAAP10K_Fujitsu():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 1859.0
+    assert result.data['assets'] == 3718259.0 
     assert result.data['gross_profit'] == 0.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 593953.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_income_loss_noncontrolling'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
@@ -736,7 +736,7 @@ def test_parse_GAAP10Q_Ez_XBRL():
     assert result.data['extraordary_items_gain_loss'] == 0.0
     assert result.data['temporary_equity'] == 0.0
     assert result.data['costs_and_expenses'] == 0.0
-    assert result.data['non_current_assets'] == -1078.0
+    assert result.data['non_current_assets'] == 58615.0 
     assert result.data['net_cash_flows_discontinued'] == 0.0
     assert result.data['income_loss'] == -7593.0
     assert result.data['liabilities_and_equity'] == 79451.0
@@ -764,10 +764,10 @@ def test_parse_GAAP10Q_Ez_XBRL():
     assert result.data['comprehensive_income_interest'] == 0.0
     assert result.data['other_comprehensive_income'] == 0.0
     assert result.data['equity_attributable_parent'] == 0.0
-    assert result.data['assets'] == 1078.0
+    assert result.data['assets'] == 79451.0 
     assert result.data['gross_profit'] == 5433.0
     assert result.data['net_cash_flows_operating_continuing'] == 0.0
-    assert result.data['current_assets'] == 0.0
+    assert result.data['current_assets'] == 20836.0
     assert result.data['interest_and_debt_expense'] == 0.0
     assert result.data['net_cash_flows_operating'] == 0.0
     assert result.data['common_shares_outstanding'] == 0.0

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -210,9 +210,9 @@ class XBRLParser(object):
             xbrl.find_all(name=re.compile("(us-gaap:)[^s]*(assetsnoncurrent)",
                           re.IGNORECASE | re.MULTILINE))
         if non_current_assets == 0 or not non_current_assets:
-            # Assets  = AssetsCurrent  +  AssetsNoncurrent 
+            # Assets  = AssetsCurrent  +  AssetsNoncurrent
             gaap_obj.non_current_assets = gaap_obj.assets \
-                    - gaap_obj.current_assets 
+                - gaap_obj.current_assets
         else:
             gaap_obj.non_current_assets = \
                 self.data_processing(non_current_assets, xbrl,

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -197,14 +197,12 @@ class XBRLParser(object):
         except IndexError:
             raise XBRLParserException('problem getting contexts')
 
-        assets = xbrl.find_all(name=re.compile("(us-gaap:)[^s]*(assets)",
-                               re.IGNORECASE | re.MULTILINE))
+        assets = xbrl.find_all("us-gaap:assets")
         gaap_obj.assets = self.data_processing(assets, xbrl,
             ignore_errors, logger, context_ids)
 
         current_assets = \
-            xbrl.find_all(name=re.compile("(us-gaap:)[^s]*(currentassets)",
-                          re.IGNORECASE | re.MULTILINE))
+            xbrl.find_all("us-gaap:assetscurrent")
         gaap_obj.current_assets = self.data_processing(current_assets,
             xbrl, ignore_errors, logger, context_ids)
 
@@ -212,8 +210,9 @@ class XBRLParser(object):
             xbrl.find_all(name=re.compile("(us-gaap:)[^s]*(assetsnoncurrent)",
                           re.IGNORECASE | re.MULTILINE))
         if non_current_assets == 0 or not non_current_assets:
-            gaap_obj.non_current_assets = gaap_obj.current_assets \
-                - gaap_obj.assets
+            # Assets  = AssetsCurrent  +  AssetsNoncurrent 
+            gaap_obj.non_current_assets = gaap_obj.assets \
+                    - gaap_obj.current_assets 
         else:
             gaap_obj.non_current_assets = \
                 self.data_processing(non_current_assets, xbrl,


### PR DESCRIPTION
- Now correctly parse current_assets. The gaap tag name is called
  us-gaap:AssetsCurrent  not "currentassets" as was being searched for.
  - Current search regexp by including [^s] would incorrectly  match on fields like
    NoncurrentAssets
- The assets tag  was also matching other unwanted terms suchs as OtherAssets.
  - These were then selected by data_processing
  - Beautiful Soup will return, when using a regexp, _all_ tags
  containing the substrings .
- The calculation for gaap_obj.non_current_assets was incorrect

- Many of the tests in tests/test_parse.py were making incorrect assertions:
  - As determined by manually looking in the xml files to find the
  correct values for a given context

  - For example
    - The test_parse_GAAP10Q_QXInteractive() this was incorrectly checking for a
        assert result.data['current_assets'] == 46431.0
        The only tag containing a value of 46431 in the file "tests/rsh-20131231.xml"
        is that for Noncurrentassets!
        It appears that this test had been written to validate the
        incorrect parsing.

        <us-gaap:NoncurrentAssets contextRef="AsOf2014-06-30" unitRef="USD" decimals="-3">46431000</us-gaap:NoncurrentAssets>