### PR TITLE
remove ordereddict dependency, issue #55

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ pytest==2.8.3
 pep8==1.6.2
 marshmallow>=2.15.1
 beautifulsoup4==4.4.1
-ordereddict==1.1
 lxml==4.6.5
 six==1.9.0

--- a/xbrl/xbrl.py
+++ b/xbrl/xbrl.py
@@ -4,7 +4,7 @@
 import re
 from marshmallow import Schema, fields
 import datetime
-import collections
+import collections as odict
 import six
 import logging
 
@@ -12,11 +12,6 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-
-if 'OrderedDict' in dir(collections):
-    odict = collections
-else:
-    import ordereddict as odict
 
 
 def soup_maker(fh):


### PR DESCRIPTION
Locally test on my env. All unit test passed.

## Test result
```
$ uname -a && grep VERSION /etc/os-release  && pytest-3 
Linux localhost 5.10.0-20-amd64 #1 SMP Debian 5.10.158-2 (2022-12-13) x86_64 GNU/Linux
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/yosuke/Data/github/python-xbrl
collected 15 items                                                             

tests/test_parse.py ...............                                      [100%]

============================= 15 passed in 11.67s ==============================
```

## requirements.txt 
```
$ for pkg in $(cut -f 1 -d '=' requirements.txt | cut -f 1 -d '>'); do python3 -m pip list | grep  $pkg ; done
pytest                   6.0.2
marshmallow              3.10.0
beautifulsoup4           4.9.3
lxml                     4.6.3
six                      1.16.0
```